### PR TITLE
Add copy colors button

### DIFF
--- a/_includes/settings.html
+++ b/_includes/settings.html
@@ -57,6 +57,7 @@
     </div>
 
     <button id="generateBtn" class="btn">Generate</button>
+    <button id="copyBtn" class="btn">Copy</button>
 
   </form>
 

--- a/js/copyGeneratedColors.js
+++ b/js/copyGeneratedColors.js
@@ -1,0 +1,39 @@
+function collectCssVariables() {
+  let cssVariables = [];
+  let themeStyles = document.querySelectorAll('style[data-theme]');
+
+  themeStyles.forEach(styleElement => {
+    let theme = styleElement.getAttribute('data-theme');
+    let cssRules = styleElement.sheet.cssRules;
+
+    let selector = theme === 'light' ? ':root' : `[data-theme="${theme}"]`;
+    cssVariables.push(`${selector} {`);
+
+    Array.from(cssRules).forEach(rule => {
+      if (rule.selectorText !== `[data-theme="${theme}"]`) return;
+      // extract the variable from the rule -> '[data-theme="dark"] { --color-seed: black; }'
+      // first remove selector, and then remove parenthesis around the variable
+
+      let cssText = rule.cssText.replace(`[data-theme="${theme}"]`, '');
+      let variable = cssText.replace(/[{}]/g, '').trim()
+      cssVariables.push(variable);
+    });
+    cssVariables.push('}');
+  });
+
+  return cssVariables.join('\n');
+}
+
+export function copyCssVariables() {
+  let cssText = collectCssVariables();
+  let copyBtn = document.getElementById('copyBtn');
+  let originalText = copyBtn.textContent;
+
+  navigator.clipboard.writeText(cssText).then(() => {
+    copyBtn.textContent = 'Copied';
+
+    setTimeout(()=>{ copyBtn.textContent = originalText }, 1000) // Display original text after 1 second
+  }).catch(err => {
+    console.error('Failed to copy: ', err);
+  });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,7 @@ import $ from 'jquery';
 import { adjustLuminanceToContrast } from '../js/adjustLuminanceToContrast.js'
 import { decreaseOpacityToContrast } from '../js/decreaseOpacityToContrast.js'
 import { setSaturation } from '../js/setSaturation.js'
+import { copyCssVariables } from '../js/copyGeneratedColors.js';
 
 const wcagNonContentContrast = 3;
 const wcagContentContrast = 4.5;
@@ -23,6 +24,11 @@ generatePalette();
 
 $('#generateBtn').on('click', function(e) {
   generatePalette();
+  e.preventDefault();
+});
+
+$('#copyBtn').on('click', function(e) {
+  copyCssVariables();
   e.preventDefault();
 });
 
@@ -85,7 +91,21 @@ function createThemeStyle(theme) {
   return style;
 }
 
+// Clear colors from css rule which are added in setCssColor.
+// This will prevent older values from getting copied.
+function clearCssColors(theme) {
+  const styleElement = document.head.querySelector(`style[data-theme="${theme}"]`);
+  if (!styleElement) return;
+
+  const { sheet } = styleElement;
+  while (sheet.cssRules.length) {
+    sheet.deleteRule(0);
+  }
+}
+
 function generatePalette() {
+  clearCssColors('light');
+  clearCssColors('dark');
 
   const accentColor = $('#accentColor').val().trim();
   const canvasContrast = $('#canvasContrast').val().trim();


### PR DESCRIPTION
## Implement 'Copy CSS' button.

Replaced generate button with copy button. 
Now on copying the css, both themes gets copied to user's clipboard.

## Demonstration video 

https://github.com/user-attachments/assets/6e0c67b5-6fa6-4a5b-8ef2-43a810c80ae5


